### PR TITLE
Add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   "bugs": {
     "url": "https://github.com/aabluedragon/zcordova-plugin-archtrim/issues"
   },
-  "homepage": "https://github.com/aabluedragon/zcordova-plugin-archtrim#readme"
+  "homepage": "https://github.com/aabluedragon/zcordova-plugin-archtrim#readme",
+  "dependencies": {
+    "xcode": "0.9.3"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "zcordova-plugin-archtrim",
+  "version": "0.1.0",
+  "description": "ArchTrimPlugin",
+  "cordova": {
+    "id": "zcordova-plugin-archtrim",
+    "platforms": [
+      "ios"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aabluedragon/zcordova-plugin-archtrim.git"
+  },
+  "keywords": [
+    "cordova",
+    "arch",
+    "ecosystem:cordova",
+    "cordova-ios"
+  ],
+  "author": "Alon Amir",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/aabluedragon/zcordova-plugin-archtrim/issues"
+  },
+  "homepage": "https://github.com/aabluedragon/zcordova-plugin-archtrim#readme"
+}


### PR DESCRIPTION
This is mostly so that it can be added without the `--nofetch` flag, but also so that it can hopefully pre-install the xcode package that it depends on. 

I had to guess at a few things, like the license, so feel free to modify as appropriate. 

To enable the no-`nofetch` add it also needs to be submitted to npm: https://cordova.apache.org/docs/en/latest/guide/hybrid/plugins/#publishing-plugins